### PR TITLE
AbstractTrees extension: avoid loss of information/semantic ambiguity

### DIFF
--- a/ext/SimpleExpressionsAbstractTreesExt.jl
+++ b/ext/SimpleExpressionsAbstractTreesExt.jl
@@ -2,7 +2,7 @@ module SimpleExpressionsAbstractTreesExt
 
 using SimpleExpressions
 import SimpleExpressions: AbstractSymbolic,
-    Symbolic, SymbolicParameter, SymbolicNumber,
+    SymbolicNumber,
     SymbolicExpression, SymbolicEquation
 
 import AbstractTrees
@@ -11,8 +11,6 @@ import AbstractTrees
 AbstractTrees.children(x::SymbolicExpression) = x.arguments
 AbstractTrees.children(x::SymbolicEquation) = MethodError(AbstractTrees.children, SymbolicExpression)
 
-AbstractTrees.nodevalue(n::Symbolic) = n.x
-AbstractTrees.nodevalue(n::SymbolicParameter) = n.p
 AbstractTrees.nodevalue(n::SymbolicNumber) = n.x
 AbstractTrees.nodevalue(n::SymbolicExpression) = n.op
 AbstractTrees.nodevalue(::SymbolicEquation) = MethodError(AbstractTrees.nodevalue, SymbolicExpression)


### PR DESCRIPTION
If `AbstractTrees.nodevalue(::Symbolic)` and
`AbstractTrees.nodevalue(::SymbolicParameter)` both return `Symbol`, it's not possible to tell apart a variable from a parameter programmatically in the tree produced from an expression by AbstractTrees.jl.

Just deleting the two methods prevents the loss of information, now `AbstractTrees.nodevalue` is just the identity function for variables and for parameters.

Fixes #43